### PR TITLE
Fix Errors in IE

### DIFF
--- a/src/lib/MultiBackend.js
+++ b/src/lib/MultiBackend.js
@@ -14,7 +14,7 @@ export default class {
     this.current = 0;
 
     this.backends = [];
-    for (const backend of options.backends) {
+    options.backends.forEach((backend) => {
       if (!backend.backend) {
         throw new Error(`You must specify a 'backend' property in your Backend entry: ${backend}`);
       }
@@ -29,7 +29,7 @@ export default class {
         preview: (backend.preview || false),
         transition,
       });
-    }
+    });
 
     this.nodes = {};
   }
@@ -75,19 +75,19 @@ export default class {
 
   // Multi Backend Listeners
   addEventListeners = (target) => {
-    for (const backend of this.backends) {
+    this.backends.forEach((backend) => {
       if (backend.transition) {
         target.addEventListener(backend.transition.event, this.backendSwitcher, true);
       }
-    }
+    });
   }
 
   removeEventListeners = (target) => {
-    for (const backend of this.backends) {
+    this.backends.forEach((backend) => {
       if (backend.transition) {
         target.removeEventListener(backend.transition.event, this.backendSwitcher, true);
       }
-    }
+    });
   }
 
   // Switching logic
@@ -95,21 +95,22 @@ export default class {
     const oldBackend = this.current;
 
     let i = 0;
-    for (const backend of this.backends) {
+    this.backends.some((backend) => {
       if (i !== this.current && backend.transition && backend.transition.check(event)) {
         this.current = i;
-        break;
+        return true;
       }
       i += 1;
-    }
+      return false;
+    });
 
     if (this.current !== oldBackend) {
       this.backends[oldBackend].instance.teardown();
-      for (const id of Object.keys(this.nodes)) {
+      Object.keys(this.nodes).forEach((id) => {
         const node = this.nodes[id];
         node.handler();
         node.handler = this.callBackend(node.func, node.args);
-      }
+      });
       this.backends[this.current].instance.setup();
 
       let newEvent = null;

--- a/src/lib/objectAssign.js
+++ b/src/lib/objectAssign.js
@@ -1,10 +1,10 @@
 export default function(target, ...sources) {
-  for (const source of sources) {
+  sources.forEach((source) => {
     for (const name in source) {
       if (Object.prototype.hasOwnProperty.call(source, name)) {
         target[name] = source[name];
       }
     }
-  }
+  });
   return target;
 }


### PR DESCRIPTION
This is a pull request fixing the Issue #7 .
It makes the Plugin work again on Internet Explorer. I know my solution is probably not the nicest one - but I thought I'd still create a pull request so you might see the problem and we can discuss how to maybe better solve it.

*The Errors cause*:
The Problem was or is that babel transpiles all `for(... of)` Loops into Iterators using `Symbol.Iterator` which is not supported on Internet Explorer. I first tried to simply Polyfill `Symbol` within my Project, but that didn't help much as the iteration part was still not working. 

*My Fix* 
I went ahead and used the fast way to simply replace all `for(...of)` Loops by native Array-Functions - `forEach` mostly and one `some` so I could fake the `break` Statement. Both are natively supported by at least IE 11 (which was my target browser). The nice thing about it is that it does not add an code-overhead and doesnt require any other babel-preset or polyfill.

*Drawback*
* The "backends"-Option now strictly needs to be an array - but since I didn't see you advocate any other type in the documentation, I did not consider this a problem (the test are also still working)
* At least in my Project, the `Preview`  does not get rendered correctly in Internext Exporer. I'm not sure though if this is simply due to my setup / configuration and I will investigate this more closely and let you know if I was able to fix it.

What do you think about the fix?
